### PR TITLE
add empty! in read! method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,6 +29,7 @@ BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FormatSpecimens = "3372ea36-2a1a-11e9-3eb7-996970b6ffbd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 
 [targets]
-test = ["BioSequences", "Documenter", "FormatSpecimens", "Test"]
+test = ["BioSequences", "Documenter", "FormatSpecimens", "Test", "CodecZlib"]

--- a/docs/src/man/gff3.md
+++ b/docs/src/man/gff3.md
@@ -49,7 +49,6 @@ record = GFF3.Record()
 
 # Iterate over records.
 while !eof(reader)
-    empty!(record)
     read!(reader, record)
     # do something
 end

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -110,6 +110,7 @@ function Base.close(reader::Reader)
 end
 
 function Base.read!(reader::Reader, record::Record)
+    empty!(record)
     return readrecord!(reader.state.stream, reader, record)
 end
 


### PR DESCRIPTION
Most BioJulia packages use 

```julia
reader = X.Reader(GzipDecompressorStream(open(file)))
record = X.Record()
read!(reader, record)
```

to read in-place, while GFF3 requires to call `empty!` before reading. This change makes it follow the same interface as the rest of the ecosystem.

I tried to reproduce the issue I ran into when I was not calling `empty!` but all the test files where already working. I still kept the additional tests.

Problematic file was this one :

https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_26/gencode.v26.basic.annotation.gff3.gz
https://www.gencodegenes.org/human/release_26.html

But it now works.

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

